### PR TITLE
fix(test): Align GTest dependency with c++14 default language level

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       max-parallel: 8
       matrix:
-        compiler: [g++-9, g++-10, g++-11, clang++-12, clang++-13, clang++-14]
+        compiler: [g++-9, g++-10, g++-11, clang++-14, clang++-15, clang++-16]
         base-flags: ["", -DJINJA2CPP_CXX_STANDARD=17]
         build-config: [Release, Debug]
         build-shared: [TRUE, FALSE]

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -62,7 +62,8 @@ if(JINJA2CPP_BUILD_TESTS)
         FetchContent_Declare(
             googletest
             GIT_REPOSITORY https://github.com/google/googletest.git
-            GIT_TAG main
+            GIT_TAG v1.16.0 # After 1.16, GTest enforce c++17 which conflict with
+                            # current c++14 default language level
         )
         FetchContent_MakeAvailable(googletest)
     endif()


### PR DESCRIPTION
latest Gtest versions (post 1.16), require c++17.
This is creating conflicts between std and nonstd facilities (optional in particular).